### PR TITLE
Add thrown exception return to allow more tests

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,12 @@ class UsageTest extends PHPUnit_Framework_TestCase
 		$this->assertException(function () {
 			throw new InvalidArgumentException('Some Message', 10);
 		}, InvalidArgumentException::class, 10, 'Some Message');
+		
+		// return the exception thrown to allow customs tests
+		$exceptionThrown = $this->assertException(function() {
+			throw new UserNotFoundException('user-id');
+		}, UserNotFoundException::class);
+		$this->assertEquals('user-id', $exceptionThrown->getUserId());
 	}
 }
 ```

--- a/src/AssertException.php
+++ b/src/AssertException.php
@@ -32,7 +32,7 @@ trait AssertException
 			self::checkExceptionInstanceOf($exception, $expectedExceptionClass);
 			self::checkExceptionCode($exception, $expectedCode);
 			self::checkExceptionMessage($exception, $expectedMessage);
-			return;
+			return $exception;
 		}
 		self::failAssertingException($expectedExceptionClass);
 	}

--- a/tests/AssertExceptionClassTest.php
+++ b/tests/AssertExceptionClassTest.php
@@ -73,7 +73,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 
 	public function testReturnType()
 	{
-	    $exception = new MyException();
+		$exception = new MyException();
 		$test = function () use ($exception) {
 			throw $exception;
 		};

--- a/tests/AssertExceptionClassTest.php
+++ b/tests/AssertExceptionClassTest.php
@@ -12,7 +12,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		AssertException::assertException($test, null);
+		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, null));
 	}
 
 	public function testClass()
@@ -20,7 +20,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyException();
 		};
-		AssertException::assertException($test, MyException::class);
+		$this->assertInstanceOf(MyException::class, AssertException::assertException($test, MyException::class));
 	}
 
 	public function testSubclass()
@@ -28,7 +28,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyException();
 		};
-		AssertException::assertException($test);
+		$this->assertInstanceOf(MyException::class, AssertException::assertException($test));
 	}
 
 	public function testSubclassOfSubclass()
@@ -36,7 +36,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyExceptionSubclass();
 		};
-		AssertException::assertException($test, MyException::class);
+		$this->assertInstanceOf(MyExceptionSubclass::class, AssertException::assertException($test, MyException::class));
 	}
 
 	public function testLowercaseClass()
@@ -44,7 +44,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		AssertException::assertException($test, 'exception');
+		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, 'exception'));
 	}
 
 	public function testFqn()
@@ -52,7 +52,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		AssertException::assertException($test, '\Exception');
+		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, '\Exception'));
 	}
 
 	public function testLowercaseFqn()
@@ -60,7 +60,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		AssertException::assertException($test, '\exception');
+		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, '\exception'));
 	}
 
 	public function testInterface()
@@ -68,7 +68,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyExceptionImplementsInterface();
 		};
-		AssertException::assertException($test, MyExceptionInterface::class);
+		$this->assertInstanceOf(MyExceptionImplementsInterface::class, AssertException::assertException($test, MyExceptionInterface::class));
 	}
 
 }

--- a/tests/AssertExceptionClassTest.php
+++ b/tests/AssertExceptionClassTest.php
@@ -12,7 +12,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, null));
+		AssertException::assertException($test, null);
 	}
 
 	public function testClass()
@@ -20,7 +20,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyException();
 		};
-		$this->assertInstanceOf(MyException::class, AssertException::assertException($test, MyException::class));
+		AssertException::assertException($test, MyException::class);
 	}
 
 	public function testSubclass()
@@ -28,7 +28,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyException();
 		};
-		$this->assertInstanceOf(MyException::class, AssertException::assertException($test));
+		AssertException::assertException($test);
 	}
 
 	public function testSubclassOfSubclass()
@@ -36,7 +36,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyExceptionSubclass();
 		};
-		$this->assertInstanceOf(MyExceptionSubclass::class, AssertException::assertException($test, MyException::class));
+		AssertException::assertException($test, MyException::class);
 	}
 
 	public function testLowercaseClass()
@@ -44,7 +44,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, 'exception'));
+		AssertException::assertException($test, 'exception');
 	}
 
 	public function testFqn()
@@ -52,7 +52,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, '\Exception'));
+		AssertException::assertException($test, '\Exception');
 	}
 
 	public function testLowercaseFqn()
@@ -60,7 +60,7 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new Exception();
 		};
-		$this->assertInstanceOf(Exception::class, AssertException::assertException($test, '\exception'));
+		AssertException::assertException($test, '\exception');
 	}
 
 	public function testInterface()
@@ -68,7 +68,16 @@ class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
 		$test = function() {
 			throw new MyExceptionImplementsInterface();
 		};
-		$this->assertInstanceOf(MyExceptionImplementsInterface::class, AssertException::assertException($test, MyExceptionInterface::class));
+		AssertException::assertException($test, MyExceptionInterface::class);
+	}
+
+	public function testReturnType()
+	{
+	    $exception = new MyException();
+		$test = function () use ($exception) {
+			throw $exception;
+		};
+		$this->assertSame($exception, AssertException::assertException($test));
 	}
 
 }


### PR DESCRIPTION
Usage sample:

``` php
$test = function() {
    throw \UserException('user-id', 'Unknown user');
}
$userException = $this->assertException($test, '\UserException', null, 'Unknown user');
$this->assertEquals('user-id', $userException->getUserId());
```
