### PR TITLE
Support for PHPUnit v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": "~7.1",
-		"phpunit/phpunit": "~5.2"
+		"phpunit/phpunit": "~6.0"
 	},
 	"autoload": {
 		"classmap": [

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 
 `AssertException` is a trait, so it can be easily used in your test case.
 
+- For PHP 7.1 and PHPUnit 6 compatibility require version `1.3`.
 - For PHP 7.1 compatibility require version `1.2`.
 - For PHP 7 compatibility require version `1.1`.
 - For PHP 5 compatibility require version `1.0`.
@@ -18,7 +19,7 @@ $ composer require vladahejda/phpunit-assert-exception
 ```php
 <?php
 
-class MyTest extends PHPUnit_Framework_TestCase
+class MyTest extends PHPUnit\Framework\TestCase
 {
 	use VladaHejda\AssertException;
 

--- a/src/AssertException.php
+++ b/src/AssertException.php
@@ -5,7 +5,6 @@ namespace VladaHejda;
 use Error;
 use Exception;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
 use ReflectionClass;
 use ReflectionException;
 use Throwable;
@@ -107,7 +106,7 @@ trait AssertException
 				$reflection = new ReflectionClass($exceptionClass);
 				$exceptionClass = $reflection->getName();
 			} catch (ReflectionException $e) {
-				PHPUnit_Framework_TestCase::fail(sprintf('An exception of type "%s" does not exist.', $exceptionClass));
+				\PHPUnit\Framework\TestCase::fail(sprintf('An exception of type "%s" does not exist.', $exceptionClass));
 			}
 
 			if (!$reflection->isInterface() && $exceptionClass !== $defaultClass && !$reflection->isSubclassOf($defaultClass)) {
@@ -121,7 +120,7 @@ trait AssertException
 					default:
 						$expectedType = 'a Throwable';
 				}
-				PHPUnit_Framework_TestCase::fail(sprintf('A class "%s" is not %s.', $exceptionClass, $expectedType));
+				\PHPUnit\Framework\TestCase::fail(sprintf('A class "%s" is not %s.', $exceptionClass, $expectedType));
 			}
 		}
 
@@ -143,7 +142,7 @@ trait AssertException
 		}
 
 		$errorMessage = sprintf('Failed asserting the class of an exception%s.', $details);
-		PHPUnit_Framework_TestCase::assertInstanceOf($expectedThrowableClass, $throwable, $errorMessage);
+		\PHPUnit\Framework\TestCase::assertInstanceOf($expectedThrowableClass, $throwable, $errorMessage);
 	}
 
 	/**
@@ -153,24 +152,24 @@ trait AssertException
 	private static function checkThrowableCode(Throwable $exception, $expectedCode)
 	{
 		if ($expectedCode !== null) {
-			PHPUnit_Framework_TestCase::assertEquals($expectedCode, $exception->getCode(), sprintf('Failed asserting the code of thrown %s.', get_class($exception)));
+			\PHPUnit\Framework\TestCase::assertEquals($expectedCode, $exception->getCode(), sprintf('Failed asserting the code of thrown %s.', get_class($exception)));
 		}
 	}
 
 	private static function checkThrowableMessage(Throwable $throwable, string $expectedMessage = null)
 	{
 		if ($expectedMessage !== null) {
-			PHPUnit_Framework_TestCase::assertContains($expectedMessage, $throwable->getMessage(), sprintf('Failed asserting the message of thrown %s.', get_class($throwable)));
+			\PHPUnit\Framework\TestCase::assertContains($expectedMessage, $throwable->getMessage(), sprintf('Failed asserting the message of thrown %s.', get_class($throwable)));
 		}
 	}
 
 	/**
 	 * @param string $expectedThrowableClass
-	 * @throws \PHPUnit_Framework_AssertionFailedError
+	 * @throws \PHPUnit\Framework\AssertionFailedError
 	 */
 	private static function failAssertingThrowable(string $expectedThrowableClass)
 	{
-		PHPUnit_Framework_TestCase::fail(sprintf('Failed asserting that %s was thrown.', $expectedThrowableClass));
+		\PHPUnit\Framework\TestCase::fail(sprintf('Failed asserting that %s was thrown.', $expectedThrowableClass));
 	}
 
 }

--- a/tests/AssertErrorTest.php
+++ b/tests/AssertErrorTest.php
@@ -5,7 +5,7 @@ namespace VladaHejda;
 use Error;
 use Exception;
 
-class AssertErrorTest extends \PHPUnit_Framework_TestCase
+class AssertErrorTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testError()

--- a/tests/AssertExceptionClassFailTest.php
+++ b/tests/AssertExceptionClassFailTest.php
@@ -4,14 +4,13 @@ namespace VladaHejda;
 
 use Error;
 use Exception;
-use PHPUnit_Framework_Exception;
 
-class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
+class AssertExceptionClassFailTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testNothingThrown()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting that Exception was thrown.');
 
 		$test = function() {
@@ -21,7 +20,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testNothingThrownWithSpecifiedClass()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage(sprintf(
 			'Failed asserting that %s was thrown.',
 			MyException::class
@@ -34,7 +33,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testUndefinedClass()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('An exception of type "UndefinedException" does not exist.');
 
 		$test = function() {
@@ -45,7 +44,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testNonException()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage(sprintf(
 			'A class "%s" is not an Exception.',
 			NotException::class
@@ -59,7 +58,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testNotInstanceOf()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting the class of an exception.');
 
 		$test = function() {
@@ -70,7 +69,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testNotInstanceOfWithCode()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting the class of an exception (code was 110).');
 
 		$test = function() {
@@ -81,7 +80,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testNotInstanceOfWithMessage()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting the class of an exception (message was "My message.").');
 
 		$test = function() {
@@ -92,7 +91,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testNotInstanceOfWithCodeAndMessage()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting the class of an exception (code was 110, message was "My message.").');
 
 		$test = function() {
@@ -113,7 +112,7 @@ class AssertExceptionClassFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testInstanceOfError()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage(sprintf('A class "%s" is not an Exception.', Error::class));
 
 		$test = function () {

--- a/tests/AssertExceptionClassTest.php
+++ b/tests/AssertExceptionClassTest.php
@@ -4,7 +4,7 @@ namespace VladaHejda;
 
 use Exception;
 
-class AssertExceptionClassTest extends \PHPUnit_Framework_TestCase
+class AssertExceptionClassTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testDefault()

--- a/tests/AssertExceptionFailTest.php
+++ b/tests/AssertExceptionFailTest.php
@@ -3,14 +3,13 @@
 namespace VladaHejda;
 
 use Exception;
-use PHPUnit_Framework_Exception;
 
-class AssertExceptionFailTest extends \PHPUnit_Framework_TestCase
+class AssertExceptionFailTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testBadCode()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting the code of thrown Exception.');
 
 		$test = function() {
@@ -21,7 +20,7 @@ class AssertExceptionFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testBadCodeOfClass()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage(sprintf(
 			'Failed asserting the code of thrown %s.',
 			MyException::class
@@ -35,7 +34,7 @@ class AssertExceptionFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testBadMessage()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage('Failed asserting the message of thrown Exception.');
 
 		$test = function() {
@@ -46,7 +45,7 @@ class AssertExceptionFailTest extends \PHPUnit_Framework_TestCase
 
 	public function testBadMessageOfClass()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage(sprintf(
 			'Failed asserting the message of thrown %s.',
 			MyException::class

--- a/tests/AssertExceptionTest.php
+++ b/tests/AssertExceptionTest.php
@@ -4,7 +4,7 @@ namespace VladaHejda;
 
 use Exception;
 
-class AssertExceptionTest extends \PHPUnit_Framework_TestCase
+class AssertExceptionTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testException()

--- a/tests/AssertExceptionTraitTest.php
+++ b/tests/AssertExceptionTraitTest.php
@@ -4,7 +4,7 @@ namespace VladaHejda;
 
 use Exception;
 
-class AssertExceptionTraitTest extends \PHPUnit_Framework_TestCase
+class AssertExceptionTraitTest extends \PHPUnit\Framework\TestCase
 {
 
 	use AssertException;

--- a/tests/AssertThrowableTest.php
+++ b/tests/AssertThrowableTest.php
@@ -4,9 +4,8 @@ namespace VladaHejda;
 
 use Error;
 use Exception;
-use PHPUnit_Framework_Exception;
 
-class AssertThrowableTest extends \PHPUnit_Framework_TestCase
+class AssertThrowableTest extends \PHPUnit\Framework\TestCase
 {
 
 	public function testThrowable()
@@ -84,7 +83,7 @@ class AssertThrowableTest extends \PHPUnit_Framework_TestCase
 
 	public function testInstanceOfError()
 	{
-		$this->expectException(PHPUnit_Framework_Exception::class);
+		$this->expectException(\PHPUnit\Framework\Exception::class);
 		$this->expectExceptionMessage(sprintf('A class "%s" is not a Throwable.', NotException::class));
 
 		$test = function () {


### PR DESCRIPTION
PHPUnit has started using namespaces in version 6, which AssertException had not yet been updated for. In effect, any test asserting that an exception would be thrown in a function would yield the following error:

```
Fatal error: Class 'PHPUnit_Framework_TestCase' not found in Foo.php
```

This PR updates the repository to support the new namespaced structure they've adopted, and proposes version 1.3 with said support.

(For what it's worth, I'm using this in a personal project. Thanks!)

/cc @VladaHejda